### PR TITLE
Replace CI with reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,55 +7,7 @@ on:
     branches: [main]
   workflow_dispatch:
 
+
 jobs:
   ci:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        id: setup-python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.11
-
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          version: 2.1.2
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-          virtualenvs-path: .venv
-          installer-parallel: true
-
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-
-      - name: Install project
-        run: poetry install --with dev --no-interaction
-
-      - name: Run pre-commit-hooks
-        run: poetry run pre-commit run --all-files --show-diff-on-failure
-
-      - name: Run tests
-        run: poetry run pytest --doctest-modules --junitxml=junit/test-results.xml --cov=visit_scheduler --cov-report=xml
-
-      - name: Upload test results
-        uses: actions/upload-artifact@v4
-        with:
-          name: pytest-results
-          path: junit/test-results.xml
-        if: ${{ always() }}
-
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-report
-          path: coverage.xml
-        if: ${{ always() }}
+    uses: 25l-ersms/25L-ersms-devops/.github/workflows/ci-python.yml@feature/14/reusable-pipelines

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,6 @@ on:
 
 jobs:
   ci:
-    uses: 25l-ersms/25L-ersms-devops/.github/workflows/ci-python.yml@feature/14/reusable-pipelines
+    uses: 25l-ersms/25L-ersms-devops/.github/workflows/ci-python.yml@main
     with:
       package-name: visit_scheduler

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,3 +11,5 @@ on:
 jobs:
   ci:
     uses: 25l-ersms/25L-ersms-devops/.github/workflows/ci-python.yml@feature/14/reusable-pipelines
+    with:
+      package-name: visit_scheduler

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,42 +6,4 @@ on:
 
 jobs:
   push_to_registry:
-    name: Push Docker image to Docker Hub
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
-      attestations: write
-      id-token: write
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v4
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-        with:
-          images: ${{ vars.DOCKER_NAMESPACE }}/ersms-visit_sched
-
-      - name: Build and push Docker image
-        id: push
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-name: docker.io/${{ vars.DOCKER_NAMESPACE }}/ersms-visit_sched
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
+    uses: 25l-ersms/25L-ersms-devops/.github/workflows/docker-build.yml@feature/14/reusable-pipelines

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Publish Docker image
 
 on:
   push:
-    # branches: [main]
+    branches: [main]
 
 jobs:
   push_to_registry:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,3 +14,5 @@ jobs:
       attestations: write
       id-token: write
     secrets: inherit
+    with:
+      img_name: ersms-visit_sched

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,3 +7,8 @@ on:
 jobs:
   push_to_registry:
     uses: 25l-ersms/25L-ersms-devops/.github/workflows/docker-build.yml@feature/14/reusable-pipelines
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   push_to_registry:
-    uses: 25l-ersms/25L-ersms-devops/.github/workflows/docker-build.yml@feature/14/reusable-pipelines
+    uses: 25l-ersms/25L-ersms-devops/.github/workflows/docker-build.yml@main
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ name: Publish Docker image
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   push_to_registry:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Publish Docker image
 
 on:
   push:
-    branches: [main]
+    # branches: [main]
 
 jobs:
   push_to_registry:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,3 +13,4 @@ jobs:
       contents: read
       attestations: write
       id-token: write
+    secrets: inherit


### PR DESCRIPTION
**What?**
- Moved common workflows to https://github.com/25l-ersms/25L-ersms-devops

**Why?**
- Avoiding duplication

**How?**
- Implemented as reusable workflows

**Testing**
- Note: workflows will fail to start until https://github.com/25l-ersms/25L-ersms-devops/pull/17 is merged, as they reference workflow files from the `main` branch
- Example runs:
  - https://github.com/25l-ersms/visit-scheduler/actions/runs/14342538297
  - https://github.com/25l-ersms/visit-scheduler/actions/runs/14342538289